### PR TITLE
Source links

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -12,7 +12,7 @@ docs: true
             
             <div class="main">
             
-                <!--<a href="https://github.com/montagejs/montagejs.org/tree/gh-pages/{{page.path}}" class="edit">Improve this</a>-->
+                <a href="https://github.com/montagestudio/docs.montagestudio.com/tree/master/{{page.path}}" class="edit">Source</a>
                 
                 <article class="content">
                     {{content}}


### PR DESCRIPTION
Add links to the GitHub source back to the MJS docs.

![screen shot 2014-07-16 at 8 47 05 am](https://cloud.githubusercontent.com/assets/378023/3592932/602ab116-0c7a-11e4-9e23-29988c1ea94c.png)
